### PR TITLE
fix deprecated paddle compat api usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Kernel Library for LLM Serving ❤️ PaddlePadddle
 >
 > ```python
 > import paddle
-> paddle.compat.enable_torch_proxy(scope={"flashinfer"})  # Enable torch proxy before importing flashinfer
+> paddle.enable_compat(scope={"flashinfer"})  # Enable torch proxy before importing flashinfer
 > import flashinfer
 > # use flashinfer
 > ```

--- a/tests/attention/test_attention_sink_blackwell.py
+++ b/tests/attention/test_attention_sink_blackwell.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import einops
 import pytest
 import torch

--- a/tests/comm/test_trtllm_allreduce_fusion_paddle.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_paddle.py
@@ -73,7 +73,7 @@ def kernel(workspace_tensor, rank, world_size):
 
 def _run_simple_worker(world_size, rank, distributed_init_port):
     # Create workspace
-    # paddle.compat.enable_torch_proxy()
+    # paddle.enable_compat()
     # Set all required environment variables
     os.environ["FLAGS_SELECTED_GPUS"] = str(rank)  # Key: set GPU ID
     os.environ["PADDLE_TRAINER_ID"] = str(rank)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Set
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import pytest
 import torch
 # from torch.torch_version import TorchVersion

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import functools
 from typing import Tuple
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Summary
- replace `paddle.compat.enable_torch_proxy(scope={"flashinfer"})` in `README.md` with `paddle.enable_compat(scope={"flashinfer"})`
- replace the remaining runtime calls in `tests/conftest.py`, `tests/moe/test_trtllm_gen_fused_moe.py`, and `tests/attention/test_attention_sink_blackwell.py` with `paddle.enable_compat()`
- update the stale commented example in `tests/comm/test_trtllm_allreduce_fusion_paddle.py`

## Verification
- `grep -R -nE "enable_torch_proxy|disable_torch_proxy" .`
- `python3 -m py_compile tests/conftest.py tests/moe/test_trtllm_gen_fused_moe.py tests/attention/test_attention_sink_blackwell.py tests/comm/test_trtllm_allreduce_fusion_paddle.py`