### PR TITLE
replace deprecated paddle compat torch proxy alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Kernel Library for LLM Serving ❤️ PaddlePadddle
 >
 > ```python
 > import paddle
-> paddle.compat.enable_torch_proxy(scope={"flashinfer"})  # Enable torch proxy before importing flashinfer
+> paddle.enable_compat(scope={"flashinfer"})  # Enable torch proxy before importing flashinfer
 > import flashinfer
 > # use flashinfer
 > ```

--- a/tests/attention/test_attention_sink_blackwell.py
+++ b/tests/attention/test_attention_sink_blackwell.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import einops
 import pytest
 import torch

--- a/tests/comm/test_trtllm_allreduce_fusion_paddle.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_paddle.py
@@ -73,7 +73,7 @@ def kernel(workspace_tensor, rank, world_size):
 
 def _run_simple_worker(world_size, rank, distributed_init_port):
     # Create workspace
-    # paddle.compat.enable_torch_proxy()
+    # paddle.enable_compat()
     # Set all required environment variables
     os.environ["FLAGS_SELECTED_GPUS"] = str(rank)  # Key: set GPU ID
     os.environ["PADDLE_TRAINER_ID"] = str(rank)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Set
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import pytest
 import torch
 # from torch.torch_version import TorchVersion

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import functools
 from typing import Tuple
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## 📌 Description

- 将仓库中的 `paddle.compat.enable_torch_proxy` 旧别名替换为公开 API `paddle.enable_compat`
- 覆盖 README 用法示例、3 个测试文件中的实际调用，以及 1 处测试注释中的旧写法
- 仅做 compat API 名称替换，不改动测试逻辑

## 🔍 Related Issues

- 无
- 背景：`paddle.compat.enable_torch_proxy` 是早期开发别名，后续将移除

## 🚀 Pull Request Checklist

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] `rg -n -F "paddle.compat.enable_torch_proxy" .` 返回 0 命中
- [x] `python3 -m py_compile tests/moe/test_trtllm_gen_fused_moe.py tests/conftest.py tests/attention/test_attention_sink_blackwell.py tests/comm/test_trtllm_allreduce_fusion_paddle.py` 通过
- [ ] Full test suite not run in this environment.

## Reviewer Notes

- 这是 compat API 公开化后的最小替换，便于后续移除旧别名
