### PR TITLE
[paddle-adapt] gemm/test_tgv_gemm + test_group_gemm: zero-diff, both PASS out-of-the-box

### DIFF
--- a/scripts/paddle_all_test_cases.sh
+++ b/scripts/paddle_all_test_cases.sh
@@ -22,3 +22,10 @@ python -m pytest -rs tests/norm/test_fused_rmsnorm_silu.py
 python -m pytest -rs tests/norm/test_fused_dit_layernorm.py
 # test_rmsnorm_fp4_quant_cute_dsl.py: SKIP - torch.float4_e2m1fn_x2 not available (requires PyTorch 2.6+, NVFP4 packed dtype)
 # test_add_rmsnorm_fp4_quant_cute_dsl.py: SKIP - same reason as above
+# test_tgv_gemm.py: PASS (90/90) - tgv_gemm_sm100 tests, SM100/SM103 hardware; no paddle adaptation needed
+# (all 90 tests SKIP on non-SM100 hardware via _match_sm_version guard)
+python -m pytest -rs tests/gemm/test_tgv_gemm.py
+# test_group_gemm.py: PASS (288/288 pass, 360 skip)
+# SKIP[288]: sm90 backend not supported on this device (upstream hardware constraint)
+# SKIP[72]: batch_size * num_rows_per_batch too large (upstream guard)
+python -m pytest -rs tests/gemm/test_group_gemm.py


### PR DESCRIPTION
## Description

Verify that tests/gemm/test_tgv_gemm.py and tests/gemm/test_group_gemm.py work under Paddle-compat mode without any source file modifications.

All APIs are either fully aligned or covered by paddle.enable_compat().

| Test file | Passed | Skipped | Reason for skips |
|---|---|---|---|
| test_tgv_gemm.py | 90 | 0 | — |
| test_group_gemm.py | 288 | 360 | sm90 hw not present (288) + batch too large (72) |

Both skip reasons are upstream hardware guards, not paddle-adaptation issues.

**Changed files**: scripts/paddle_all_test_cases.sh: +7 lines

**No paddle-adaptation changes**: git diff upstream/0.6 -- *.py *.h *.cu *.cc = 0 lines

**Regression**:
- norm/test_fused_rmsnorm_silu: PASS
- norm/test_fused_dit_layernorm: PASS (35/35)
- comm/test_trtllm_allreduce_fusion: PASS (1/1)
- attention_sink / moe_smoke: pre-existing CCCL submodule issue (not caused by this PR)

## Related Issues

N/A

## Pull Request Checklist

- [x] pre-commit run --files scripts/paddle_all_test_cases.sh: all checks passed

## Tests

- [x] test_tgv_gemm.py: 90/90 PASS
- [x] test_group_gemm.py: 288 PASS, 360 SKIP (hardware constraints)
- [x] Regression tests (norm, allreduce) PASS

## Reviewer Notes

This PR only adds 7 lines to the shell test script. Zero changes to Python/C++ source.
The test files run out-of-the-box under paddle.enable_compat() -- no adaptation needed.