### PR TITLE
[paddle-adapt] fix: find and load libcudart dynamically via /proc/self/maps

### DIFF
--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 import ctypes
 import functools
 import os
+from typing import Optional
 
 # Re-export
 from . import cubin_loader
@@ -99,8 +100,38 @@ from .fp4_kv_quantization import (
 )
 
 
+def find_loaded_library(lib_name) -> Optional[str]:
+    """
+    According to according to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
+    the file  contains the memory maps of the process, which includes the
+    shared libraries loaded by the process. We can use this file to find the path of the
+    a loaded library.
+    """
+    found = False
+    with open("/proc/self/maps") as f:
+        for line in f:
+            if lib_name in line:
+                found = True
+                break
+    if not found:
+        # the library is not loaded in the current process
+        return None
+    # if lib_name is libcudart, we need to match a line with:
+    # address /path/to/libcudart-hash.so.11.0
+    start = line.index("/")
+    path = line[start:].strip()
+    filename = path.split("/")[-1]
+    assert filename.rpartition(".so")[0].startswith(lib_name), (
+        f"Unexpected filename: {filename} for library {lib_name}"
+    )
+    return path
+
+
 cuda_lib_path = os.environ.get(
     "CUDA_LIB_PATH", "/usr/local/cuda/targets/x86_64-linux/lib/"
 )
-if os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
+process_cudart_path = find_loaded_library("libcudart")
+if process_cudart_path is not None:
+    ctypes.CDLL(process_cudart_path, mode=ctypes.RTLD_GLOBAL)
+elif os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
     ctypes.CDLL(f"{cuda_lib_path}/libcudart.so.12", mode=ctypes.RTLD_GLOBAL)


### PR DESCRIPTION
## 📌 Description

Fix loading cudart.so by dynamically discovering the already-loaded library path via `/proc/self/maps` before falling back to the hardcoded `CUDA_LIB_PATH`.

**Problem:** The hardcoded path `${CUDA_LIB_PATH}/libcudart.so.12` often does not exist in PaddlePaddle environments (different CUDA installation layout), causing `flashinfer.jit` to silently skip loading cudart and leading to downstream JIT compilation failures.

**Fix:** Added `find_loaded_library(lib_name)` that reads `/proc/self/maps` to locate the already-in-process cudart .so, using that path first. The hardcoded fallback is retained for backward compatibility.

**Changes:**
- `flashinfer/jit/__init__.py`: +32/-1, add `find_loaded_library()` + update cudart loading order

**Regression verified (fi_paddle env):**
- norm/test_fused_rmsnorm_silu: ✅ PASS
- norm/test_fused_dit_layernorm: ✅ 35 passed
- moe/test_fp8_block_scale_routed_activation_type_relu2_smoke: ✅ PASS

## 🔍 Related Issues

Backport of PFCCLab/flashinfer@dedaff12d772dd1bcae349e0cfa68fe3ac896249 to the 0.6 branch.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Installed pre-commit via `pip install pre-commit`
- [x] Installed hooks with `pre-commit install`
- [x] Ran `pre-commit run --files flashinfer/jit/__init__.py` — all hooks passed (ruff-format auto-fixed, ruff check ✅, mypy ✅)

## 🧪 Tests

- [x] No test files modified (pure bug fix in library loading)
- [x] Regression tests passing: norm/rmsnorm_silu, dit_layernorm (35 passed), moe smoke test

## Reviewer Notes

Minimal, self-contained fix. Only `flashinfer/jit/__init__.py` is changed. The `find_loaded_library` function gracefully returns `None` when not found, fully preserving backward compatibility.
